### PR TITLE
Added menu navigation to see all cards of a cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "taffydb": "^2.7.3",
     "vue": "^2.4.2",
     "vue-analytics": "^4.4.0",
+    "vue-awesome": "^3.5.4",
     "vue-chartjs": "^3.1.1",
     "vue-cli": "^2.8.2",
     "vue-i18n": "^7.2.0",

--- a/src/components/App/Navbar.vue
+++ b/src/components/App/Navbar.vue
@@ -19,7 +19,12 @@
                                                 :key="cycle.id"
                                                 role="button">
                                         {{ cycle.name }}
-                                        <v-icon :key="cycle.id + '_caret_down'" name="caret-down" scale="0.75"></v-icon>
+                                        <span class="when-opened">
+                                          <v-icon :key="cycle.id + '_caret_down'" name="caret-down" scale="0.75"></v-icon>
+                                        </span>
+                                        <span class="when-closed">
+                                          <v-icon :key="cycle.id + '_caret_right'" name="caret-right" scale="0.75"></v-icon>
+                                        </span>
                             </b-dropdown-header> 
                             <b-collapse :id="cycle.id"
                                         :key="cycle.id + '_collapse'"
@@ -115,7 +120,7 @@
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
-<style>
+<style scoped>
   .cycle-header {
     font-size: 1em;
   }
@@ -123,4 +128,9 @@
   .cycle-header:hover {
     cursor: pointer;
   }
+
+  .collapsed > .when-opened,
+    :not(.collapsed) > .when-closed {
+        display: none;
+    }
 </style>

--- a/src/components/App/Navbar.vue
+++ b/src/components/App/Navbar.vue
@@ -13,12 +13,14 @@
                         <b-dropdown-item :to="{name:'cards-by-default'}" exact>All</b-dropdown-item>
                         <template v-for="cycle in cycles">
                             <b-dropdown-item 
+                                    class="small-dropdown-text"
                                     v-if="cycle.size > 0"
                                     :key="cycle.id"
                                     :to="{name:'cards-by-cycle-id', params: {id : cycle.id}}">
                                 <b>{{ cycle.name }}</b>
                             </b-dropdown-item>
                             <b-dropdown-item
+                                    class="small-dropdown-text"
                                     v-for="pack in cycle.packs"
                                     :key="pack.id"
                                     :to="{name:'cards-by-pack-id', params: { id : pack.id}}"
@@ -104,4 +106,7 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
+  .small-dropdown-text {
+    font-size: 0.8em;
+  }
 </style>

--- a/src/components/App/Navbar.vue
+++ b/src/components/App/Navbar.vue
@@ -22,7 +22,8 @@
                                         <v-icon :key="cycle.id + '_caret_down'" name="caret-down" scale="0.75"></v-icon>
                             </b-dropdown-header> 
                             <b-collapse :id="cycle.id"
-                                        :key="cycle.id + '_collapse'">
+                                        :key="cycle.id + '_collapse'"
+                                        accordion="cycle-accordion">
                               <b-dropdown-item  v-if="cycle.size > 1" 
                                                 :to="{name:'cards-by-cycle-id', params: {id : cycle.id}}">
                                   <b>All cards of {{ cycle.name }}</b>

--- a/src/components/App/Navbar.vue
+++ b/src/components/App/Navbar.vue
@@ -12,21 +12,30 @@
                     <b-nav-item-dropdown text="Cards" left :class="[ section === 'cards' ? 'active' : '']">
                         <b-dropdown-item :to="{name:'cards-by-default'}" exact>All</b-dropdown-item>
                         <template v-for="cycle in cycles">
-                            <b-dropdown-item 
-                                    class="small-dropdown-text"
-                                    v-if="cycle.size > 0"
-                                    :key="cycle.id"
-                                    :to="{name:'cards-by-cycle-id', params: {id : cycle.id}}">
-                                <b>{{ cycle.name }}</b>
-                            </b-dropdown-item>
-                            <b-dropdown-item
-                                    class="small-dropdown-text"
-                                    v-for="pack in cycle.packs"
-                                    :key="pack.id"
-                                    :to="{name:'cards-by-pack-id', params: { id : pack.id}}"
-                                    exact>
-                                  {{ pack.name }}
-                            </b-dropdown-item>
+                          <b-dropdown-divider :key="cycle.name + '_divider'"/>
+                          <template v-if="cycle.size >= 1">
+                            <b-dropdown-header  v-b-toggle="cycle.id"
+                                                class="cycle-header"
+                                                :key="cycle.id"
+                                                role="button">
+                                        {{ cycle.name }}
+                                        <v-icon :key="cycle.id + '_caret_down'" name="caret-down" scale="0.75"></v-icon>
+                            </b-dropdown-header> 
+                            <b-collapse :id="cycle.id"
+                                        :key="cycle.id + '_collapse'">
+                              <b-dropdown-item  v-if="cycle.size > 1" 
+                                                :to="{name:'cards-by-cycle-id', params: {id : cycle.id}}">
+                                  <b>All cards of {{ cycle.name }}</b>
+                              </b-dropdown-item>
+                              <b-dropdown-item
+                                      v-for="pack in cycle.packs"
+                                      :key="pack.id"
+                                      :to="{name:'cards-by-pack-id', params: { id : pack.id}}"
+                                      exact>
+                                      {{ pack.name }}
+                              </b-dropdown-item>
+                            </b-collapse> 
+                          </template>
                         </template>
                     </b-nav-item-dropdown>
                     <b-nav-item
@@ -106,7 +115,11 @@
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-  .small-dropdown-text {
-    font-size: 0.8em;
+  .cycle-header {
+    font-size: 1em;
+  }
+
+  .cycle-header:hover {
+    cursor: pointer;
   }
 </style>

--- a/src/components/App/Navbar.vue
+++ b/src/components/App/Navbar.vue
@@ -12,13 +12,18 @@
                     <b-nav-item-dropdown text="Cards" left :class="[ section === 'cards' ? 'active' : '']">
                         <b-dropdown-item :to="{name:'cards-by-default'}" exact>All</b-dropdown-item>
                         <template v-for="cycle in cycles">
-                            <b-dropdown-header v-if="cycle.size > 1">{{ cycle.name }}</b-dropdown-header>
+                            <b-dropdown-item 
+                                    v-if="cycle.size > 0"
+                                    :key="cycle.id"
+                                    :to="{name:'cards-by-cycle-id', params: {id : cycle.id}}">
+                                <b>{{ cycle.name }}</b>
+                            </b-dropdown-item>
                             <b-dropdown-item
                                     v-for="pack in cycle.packs"
                                     :key="pack.id"
-                                    :to="{name:'cards-by-pack-id',params:{id:pack.id}}"
+                                    :to="{name:'cards-by-pack-id', params: { id : pack.id}}"
                                     exact>
-                                {{ pack.name }}
+                                  {{ pack.name }}
                             </b-dropdown-item>
                         </template>
                     </b-nav-item-dropdown>

--- a/src/components/Cards/Browser.vue
+++ b/src/components/Cards/Browser.vue
@@ -233,6 +233,8 @@
             return `${stores.cards({ id: route.params.id }).first().name} • Card` || defaultTitle;
           case 'cards-by-pack-id':
             return `${stores.packs({ id: route.params.id }).first().name} • Pack` || defaultTitle;
+          case 'cards-by-cycle-id':
+            return `${stores.cycles({ id: route.params.id }).first().name} • Cycle` || defaultTitle;
           case 'cards-by-clan-id':
             return `${this.$t(`clan.${route.params.id}`)} • Clan` || defaultTitle;
           default:

--- a/src/main.js
+++ b/src/main.js
@@ -12,12 +12,14 @@ import moment from 'moment';
 import './style.css';
 import './colors.css';
 import './font.css';
+import 'vue-awesome/icons'
 
 import store from './store';
 import router from './router';
 import i18n from './i18n';
 
 import { load } from './service/storeService';
+import Icon from 'vue-awesome/components/Icon'
 
 import AppNavbar from './components/App/Navbar';
 import AppFooter from './components/App/Footer';
@@ -25,6 +27,7 @@ import UtilsCardModale from './components/Utils/CardModale';
 import UtilsCardPopover from './components/Utils/CardPopover';
 
 Vue.config.productionTip = false;
+Vue.component('v-icon', Icon)
 
 sync(store, router);
 Vue.use(VueAnalytics, {

--- a/src/router.js
+++ b/src/router.js
@@ -61,6 +61,13 @@ export default new Router({
       meta: { section: 'cards' },
     },
     {
+      path: '/cycle/:id',
+      name: 'cards-by-cycle-id',
+      component: Browser,
+      props: true,
+      meta: { section: 'cards' },
+    },
+    {
       path: '/clan/:id',
       name: 'cards-by-clan-id',
       component: Browser,

--- a/src/service/queryMapper.js
+++ b/src/service/queryMapper.js
@@ -16,60 +16,120 @@ class QueryMapper {
         type: 'id',
         description: 'Card Id',
       },
+      text: {
+        name: 'text_canonical',
+        type: 'string',
+        description: 'Card Text',
+      },
       x: {
         name: 'text_canonical',
         type: 'string',
         description: 'Card Text',
+      },
+      pack: {
+        name: 'packs',
+        type: 'join',
+        description: 'Pack',
       },
       p: {
         name: 'packs',
         type: 'join',
         description: 'Pack',
       },
+      cycle: {
+        name: 'cycles',
+        type: 'join',
+        description: 'Cycle',
+      },
       y: {
         name: 'cycles',
         type: 'join',
         description: 'Cycle',
+      },
+      clan: {
+        name: 'clan',
+        type: 'id',
+        description: 'Card Clan',
       },
       c: {
         name: 'clan',
         type: 'id',
         description: 'Card Clan',
       },
+      type: {
+        name: 'type',
+        type: 'id',
+        description: 'Card Type',
+      },
       t: {
         name: 'type',
         type: 'id',
         description: 'Card Type',
+      },
+      side: {
+        name: 'side',
+        type: 'id',
+        description: 'Card Deck',
       },
       d: {
         name: 'side',
         type: 'id',
         description: 'Card Deck',
       },
+      trait: {
+        name: 'traits',
+        type: 'join',
+        description: 'Traits',
+      },
       k: {
         name: 'traits',
         type: 'join',
         description: 'Traits',
+      },
+      influence: {
+        name: 'influence_cost',
+        type: 'integer',
+        description: 'Influence Cost',
       },
       i: {
         name: 'influence_cost',
         type: 'integer',
         description: 'Influence Cost',
       },
+      cost: {
+        name: 'cost',
+        type: 'integer',
+        description: 'Fate Cost',
+      },
       f: {
         name: 'cost',
         type: 'integer',
         description: 'Fate Cost',
+      },
+      unicity: {
+        name: 'unicity',
+        type: 'boolean',
+        description: 'Unique',
       },
       u: {
         name: 'unicity',
         type: 'boolean',
         description: 'Unique',
       },
+      glory: {
+        name: 'glory',
+        type: 'integer',
+        description: 'Glory',
+      },
       g: {
         name: 'glory',
         type: 'integer',
         description: 'Glory',
+      },
+      element: {
+        name: 'element',
+        type: 'id',
+        description: 'Element',
       },
       e: {
         name: 'element',

--- a/src/service/queryParser.js
+++ b/src/service/queryParser.js
@@ -57,7 +57,7 @@ class QueryParser {
     }
 
     // looking for a type
-    const match = this.findToken('(\\w{1,3})([:<>!])');
+    const match = this.findToken('(\\w{1,9})([:<>!])');
     if (match) {
       // we have found a token "{condition}:"
       this.clause.name = match[1].toLowerCase();

--- a/src/service/queryRouter.js
+++ b/src/service/queryRouter.js
@@ -5,8 +5,11 @@ class QueryRouter {
     this.config = {
       id: 'cards-by-card-id',
       p: 'cards-by-pack-id',
+      pack: 'cards-by-pack-id',
       c: 'cards-by-clan-id',
-      y: 'cards-by-cycle-id'
+      clan: 'cards-by-clan-id',
+      y: 'cards-by-cycle-id',
+      cycle: 'cards-by-cycle-id'
     };
     this.reverseMatching = {
       'cards-by-search-query': function matcher(route) {
@@ -16,13 +19,13 @@ class QueryRouter {
         return `id:${route.params.id}`;
       },
       'cards-by-pack-id': function matcher(route) {
-        return `p:${route.params.id}`;
+        return `pack:${route.params.id}`;
       },
       'cards-by-clan-id': function matcher(route) {
-        return `c:${route.params.id}`;
+        return `clan:${route.params.id}`;
       },
       'cards-by-cycle-id': function matcher(route) {
-        return `y:${route.params.id}`;
+        return `cycle:${route.params.id}`;
       },
       'cards-by-default': '',
     };

--- a/src/service/queryRouter.js
+++ b/src/service/queryRouter.js
@@ -6,6 +6,7 @@ class QueryRouter {
       id: 'cards-by-card-id',
       p: 'cards-by-pack-id',
       c: 'cards-by-clan-id',
+      y: 'cards-by-cycle-id'
     };
     this.reverseMatching = {
       'cards-by-search-query': function matcher(route) {
@@ -19,6 +20,9 @@ class QueryRouter {
       },
       'cards-by-clan-id': function matcher(route) {
         return `c:${route.params.id}`;
+      },
+      'cards-by-cycle-id': function matcher(route) {
+        return `y:${route.params.id}`;
       },
       'cards-by-default': '',
     };


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8974341/60585080-25b4c980-9d8f-11e9-9a3c-040b4414898f.png)
![image](https://user-images.githubusercontent.com/8974341/60585106-349b7c00-9d8f-11e9-8966-edf3f5a7fba7.png)
Adds expandable cycles (accordion, so only one can be open at the same time), as suggested in #47 

